### PR TITLE
Suggestion to fix deprecation messages in Symfony 4.3

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace Cethyworks\ContentInjectorBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use App\Kernel;
 
 /**
  * This is the class that validates and merges configuration from your app/config files.
@@ -17,8 +18,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('cethyworks_content_injector');
+        if (Kernel::VERSION_ID >= 40200) {
+            $treeBuilder = new TreeBuilder('cethyworks_content_injector');
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('cethyworks_content_injector');
+        }
 
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for

--- a/src/Form/Extension/InjectorAwareTypeExtension.php
+++ b/src/Form/Extension/InjectorAwareTypeExtension.php
@@ -31,12 +31,23 @@ class InjectorAwareTypeExtension extends AbstractTypeExtension
 
     /**
      * Returns the name of the type being extended.
+     * Kept and modified for Symfony < 4.2, its deprecated and replaced by static function below.
      *
      * @return string The name of the type being extended
      */
     public function getExtendedType()
     {
-        return FormType::class;
+        return self::getExtendedTypes()[0];
+    }
+
+    /**
+     * Gets the extended types - not implementing it is deprecated since Symfony 4.2.
+     *
+     * @return array The name of the type being extended
+     */
+    public static function getExtendedTypes()
+    {
+        return [FormType::class];
     }
 
     /**


### PR DESCRIPTION
Class "Cethyworks\ContentInjectorBundle\Form\Extension\InjectorAwareTypeExtension" should implement method "static Symfony\Component\Form\FormTypeExtensionInterface::getExtendedTypes()": Gets the extended types - not implementing it is deprecated since Symfony 4.2.

Fixed by 2d4ffb7.

The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "cethyworks_content_injector" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.

Fixed by 8cda6b3.

I believe this should fix and also working backwards.